### PR TITLE
Late WorldLoader ctor hook for CRS compatibility

### DIFF
--- a/SlugBase/SlugBaseMod.cs
+++ b/SlugBase/SlugBaseMod.cs
@@ -72,6 +72,7 @@ namespace SlugBase
         {
             // Compatibility fixes (applied over other hooks)
             Compatibility.FancySlugcats.Apply();
+            WorldFixes.LateApply();
 
             orig(self);
             On.RainWorld.Start -= RainWorld_Start;

--- a/SlugBase/WorldFixes.cs
+++ b/SlugBase/WorldFixes.cs
@@ -15,7 +15,8 @@ namespace SlugBase
             On.Menu.FastTravelScreen.InitiateRegionSwitch += FastTravelScreen_InitiateRegionSwitch;
             On.Menu.FastTravelScreen.ctor += FastTravelScreen_ctor;
 
-            On.WorldLoader.ctor += WorldLoader_ctor;
+            //On.WorldLoader.ctor += WorldLoader_ctor;
+            // deferred, moved to start
 
             On.RoomSettings.ctor += RoomSettings_ctor;
 
@@ -24,6 +25,11 @@ namespace SlugBase
 
             On.EventTrigger.FromString += EventTrigger_FromString;
             On.EventTrigger.ctor += EventTrigger_ctor;
+        }
+
+        internal static void LateApply()
+        {
+            On.WorldLoader.ctor += WorldLoader_ctor;
         }
 
         // FastTravelScreen


### PR DESCRIPTION
Current CRS doesn't call orig on its WorldLoader ctor for custom worlds so other hooks to the method were load-order dependent. Deferred hooking so its on top of it.